### PR TITLE
Check SNS subscription

### DIFF
--- a/src/dashboard_mgmt_function/dashboard_mgmt.py
+++ b/src/dashboard_mgmt_function/dashboard_mgmt.py
@@ -152,7 +152,7 @@ def build_dashboard(event):
             'inference_resources': inference_resource_datas
         })
 
-    template_data['dataset_groups'] = dsgs_for_template
+    template_data['dataset_groups'] = sorted(dsgs_for_template, key = lambda dsg: dsg['region'] + dsg['name'])
 
     # Render template and use as dashboard body.
     with open('dashboard-template.mustache', 'r') as f:

--- a/template.yaml
+++ b/template.yaml
@@ -16,7 +16,7 @@ Metadata:
     ReadmeUrl: README-SAR.md
     Labels: ['Personalize', 'CloudWatch', 'Monitoring']
     HomePageUrl: https://github.com/aws-samples/amazon-personalize-monitor
-    SemanticVersion: 1.2.0
+    SemanticVersion: 1.2.1
     SourceCodeUrl: https://github.com/aws-samples/amazon-personalize-monitor
 
   AWS::CloudFormation::Interface:
@@ -203,9 +203,15 @@ Resources:
             Effect: Allow
             Action:
               - sns:CreateTopic
+              - sns:ListSubscriptionsByTopic
               - sns:SetTopicAttributes
               - sns:Subscribe
             Resource: !Sub 'arn:${AWS::Partition}:sns:*:${AWS::AccountId}:PersonalizeMonitorNotifications'
+          - Sid: SnsSubPolicy
+            Effect: Allow
+            Action:
+              - sns:GetSubscriptionAttributes
+            Resource: '*'
       Events:
         ScheduledEvent:
           Type: Schedule


### PR DESCRIPTION
*Description of changes:*

- Added logic to check SNS subscription before subscribing notification endpoint. This will prevent multiple subscription confirmation emails from being sent by SNS.
- Add simple sort to dashboard DSGs so they're rendered in consistent order when dashboard is rebuilt.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
